### PR TITLE
Update CaptureChunk.java

### DIFF
--- a/TownsAndNations-Common/src/main/java/org/leralix/tan/war/capture/CaptureChunk.java
+++ b/TownsAndNations-Common/src/main/java/org/leralix/tan/war/capture/CaptureChunk.java
@@ -100,7 +100,7 @@ public class CaptureChunk {
                     nbAttackers,
                     nbDefenders
             );
-        } else if (score > 0) {
+        } else if (score > 0 && score < Constants.getChunkCaptureTime()) {
             return Lang.WAR_INFO_CONTESTED.get(
                     getAttackingTerritory().getColoredName(),
                     NumberUtil.getPercentage(score, Constants.getChunkCaptureTime()),


### PR DESCRIPTION
When capturing progress reaches 100%, the chunk still displays as contested and as a result shows the wrong territory name

Before:
<img width="657" height="180" alt="image" src="https://github.com/user-attachments/assets/9194244d-3157-4779-9a89-722df2c7f1bb" />

After:
<img width="682" height="123" alt="image" src="https://github.com/user-attachments/assets/dd1a91cd-b462-4e26-b358-c2322ee9dee3" />