### PR TITLE
bug: Available chunks to conquer displays incorrect territory.

### DIFF
--- a/TownsAndNations-Common/src/main/java/org/leralix/tan/gui/user/territory/WarsMenu.java
+++ b/TownsAndNations-Common/src/main/java/org/leralix/tan/gui/user/territory/WarsMenu.java
@@ -49,7 +49,7 @@ public class WarsMenu extends IteratorGUI {
                 continue;
             }
 
-            desc.add(Lang.CHUNK_CONQUER_DESC.get(territoryData.getColoredName(), Integer.toString(quantity)));
+            desc.add(Lang.CHUNK_CONQUER_DESC.get(territory.getColoredName(), Integer.toString(quantity)));
         }
 
         if(desc.isEmpty()){


### PR DESCRIPTION
Available chunks to conquer displays the territory of the player's own nation rather than the territory that has available chunks to be conquered.

Before:
<img width="508" height="183" alt="image" src="https://github.com/user-attachments/assets/f1c0ba95-19f9-4f99-b403-fbcf47aad2ea" />

After:
<img width="484" height="179" alt="image" src="https://github.com/user-attachments/assets/9bd5ba9b-319c-405f-b9b5-a26fc8ac4d8a" />


